### PR TITLE
Egen kafkaconsumer for subsumsjon brukt

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/api/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/Configuration.kt
@@ -23,8 +23,9 @@ private val localProperties = ConfigurationMap(
         "application.profile" to "LOCAL",
         "application.httpPort" to "8092",
         "auth.secret" to "secret",
-        "auth.allowedKeys" to "secret1, secret2"
-    )
+        "auth.allowedKeys" to "secret1, secret2",
+        "kafka.subsumsjon.topic" to "privat-dagpenger-subsumsjon-brukt"
+)
 )
 private val devProperties = ConfigurationMap(
     mapOf(
@@ -34,7 +35,8 @@ private val devProperties = ConfigurationMap(
         "vault.mountpath" to "postgresql/preprod-fss/",
         "kafka.bootstrap.servers" to "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
         "application.profile" to "DEV",
-        "application.httpPort" to "8092"
+        "application.httpPort" to "8092",
+        "kafka.subsumsjon.topic" to "privat-dagpenger-subsumsjon-brukt"
 
     )
 )
@@ -46,7 +48,8 @@ private val prodProperties = ConfigurationMap(
         "vault.mountpath" to "postgresql/prod-fss/",
         "kafka.bootstrap.servers" to "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl150.adeo.no:8443",
         "application.profile" to "PROD",
-        "application.httpPort" to "8092"
+        "application.httpPort" to "8092",
+        "kafka.subsumsjon.topic" to "privat-dagpenger-subsumsjon-brukt"
     )
 )
 
@@ -63,9 +66,10 @@ internal data class Configuration(
     val database: Database = Database(),
     val vault: Vault = Vault(),
     val kafka: Kafka = Kafka(),
-    val application: Application = Application()
-
+    val application: Application = Application(),
+    val subsumsjonBruktTopic: String = config()[Key("kafka.subsumsjon.topic", stringType)]
 ) {
+
     data class Auth(
         val secret: String = config()[Key("auth.secret", stringType)],
         val allowedKeys: List<String> = config()[Key("auth.allowedKeys", listType(stringType))],

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
@@ -1,9 +1,10 @@
 package no.nav.dagpenger.regel.api.db
 
+import no.nav.dagpenger.regel.api.moshiInstance
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
-internal interface BruktSubsumsjonStore {
+interface BruktSubsumsjonStore {
     fun insertSubsumsjonBrukt(subsumsjonBrukt: SubsumsjonBrukt): Int
     fun getSubsumsjonBrukt(subsumsjonsId: String): SubsumsjonBrukt?
     fun subsumsjonBruktFraVedtak(vedtakId: String): SubsumsjonBrukt?
@@ -14,7 +15,19 @@ data class SubsumsjonBrukt(
     val eksternId: String,
     val arenaTs: ZonedDateTime,
     val ts: Long
-)
+) {
+    companion object Mapper {
+        private val adapter = moshiInstance.adapter<SubsumsjonBrukt>(SubsumsjonBrukt::class.java)
+        fun fromJson(json: String): SubsumsjonBrukt? {
+            return adapter.fromJson(json)
+        }
+    }
+
+    fun toJson(): String {
+        return adapter.toJson(this)
+    }
+}
+
 val isoFormat = DateTimeFormatter.ISO_ZONED_DATE_TIME
 
 internal class SubsumsjonBruktNotFoundException(override val message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
@@ -1,5 +1,6 @@
 package no.nav.dagpenger.regel.api.db
 
+import mu.KotlinLogging
 import no.nav.dagpenger.regel.api.moshiInstance
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -17,9 +18,10 @@ data class SubsumsjonBrukt(
     val ts: Long
 ) {
     companion object Mapper {
+        private val LOGGER = KotlinLogging.logger { }
         private val adapter = moshiInstance.adapter<SubsumsjonBrukt>(SubsumsjonBrukt::class.java)
         fun fromJson(json: String): SubsumsjonBrukt? {
-            return adapter.fromJson(json)
+            return runCatching { adapter.fromJson(json) }.onFailure { e -> LOGGER.warn("Failed to convert string to object", e) }.getOrNull()
         }
     }
 

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/streams/KafkaSubsumsjonBruktConsumer.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/streams/KafkaSubsumsjonBruktConsumer.kt
@@ -1,0 +1,77 @@
+package no.nav.dagpenger.regel.api.streams
+
+import mu.KotlinLogging
+import no.nav.dagpenger.plain.consumerConfig
+import no.nav.dagpenger.regel.api.Configuration
+import no.nav.dagpenger.regel.api.db.BruktSubsumsjonStore
+import no.nav.dagpenger.regel.api.db.SubsumsjonBrukt
+import no.nav.dagpenger.regel.api.monitoring.HealthCheck
+import no.nav.dagpenger.regel.api.monitoring.HealthStatus
+import no.nav.dagpenger.streams.KafkaCredential
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.errors.RetriableException
+import org.apache.kafka.common.serialization.StringDeserializer
+import java.time.Duration
+
+private val LOGGER = KotlinLogging.logger { }
+
+internal class KafkaSubsumsjonBruktConsumer(val config: Configuration, val bruktSubsumsjonStore: BruktSubsumsjonStore) :
+    HealthCheck {
+    val SERVICE_APP_ID = "dp-regel-api-sub-brukt"
+    var poll = false
+
+    override fun status(): HealthStatus {
+        return if (poll) {
+            HealthStatus.UP
+        } else {
+            HealthStatus.DOWN
+        }
+    }
+
+    suspend fun start() {
+        LOGGER.info { "Starting KafkaSubsumsjonBrukt consumer" }
+        listen()
+    }
+
+    fun stop() {
+        LOGGER.info { "Stopping KafkaSubsumsjonBrukt consumer" }
+        poll = false
+    }
+
+    private fun listen() {
+        val creds = config.kafka.user?.let { u ->
+            config.kafka.password?.let { p ->
+                KafkaCredential(username = u, password = p)
+            }
+        }
+        KafkaConsumer<String, String>(
+            consumerConfig(
+                groupId = SERVICE_APP_ID,
+                bootstrapServerUrl = config.kafka.brokers,
+                credential = creds
+            ).also {
+                it[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+                it[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+            }
+        ).use { consumer ->
+            poll = true
+            try {
+                consumer.subscribe(listOf(config.subsumsjonBruktTopic))
+                while (poll) {
+                    val records = consumer.poll(Duration.ofMillis(1000))
+                    records.asSequence()
+                        .map { r -> SubsumsjonBrukt.fromJson(r.value()) }
+                        .filterNotNull()
+                        .onEach { b -> LOGGER.info("Saving $b to database") }
+                        .forEach { bruktSubsumsjonStore.insertSubsumsjonBrukt(it) }
+                }
+            } catch (e: RetriableException) {
+                LOGGER.warn("Kafka threw a retriable exception, looping back", e)
+            } catch (e: Exception) {
+                poll = false
+                LOGGER.error("Unexpected exception while consuming messages. Stopping", e)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I og med at vedtakslytter produserer kafka meldingen, så kan regel-api også consume istedet for å gjøre ett http kall.