### PR TITLE
Resultatet fra dagpengereglene skal ikke spares hvis vedtaket avbrytes.

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/BruktSubsumsjonStore.kt
@@ -8,17 +8,19 @@ import java.time.format.DateTimeFormatter
 
 interface BruktSubsumsjonStore {
     fun insertSubsumsjonBrukt(internSubsumsjonBrukt: InternSubsumsjonBrukt): Int
-    fun getSubsumsjonBrukt(subsumsjonsId: SubsumsjonId): InternSubsumsjonBrukt?
+    fun getSubsumsjonBrukt(subsumsjonId: SubsumsjonId): InternSubsumsjonBrukt?
     fun listSubsumsjonBrukt(): List<InternSubsumsjonBrukt>
     fun subsumsjonBruktFraBehandlingsId(behandlingsId: String): List<InternSubsumsjonBrukt>
-    fun eksternTilInternSubsumsjon(v1: EksternSubsumsjonBrukt): InternSubsumsjonBrukt
+    fun eksternTilInternSubsumsjon(eksternSubsumsjonBrukt: EksternSubsumsjonBrukt): InternSubsumsjonBrukt
 }
 
 data class EksternSubsumsjonBrukt(
     val id: String,
     val eksternId: Long,
     val arenaTs: ZonedDateTime,
-    val ts: Long
+    val ts: Long,
+    val utfall: String? = null,
+    val vedtakStatus: String? = null
 ) {
     companion object Mapper {
         private val LOGGER = KotlinLogging.logger { }

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/PostgresBruktSubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/PostgresBruktSubsumsjonStore.kt
@@ -53,14 +53,19 @@ class PostgresBruktSubsumsjonStore(
         }
     }
 
-    override fun eksternTilInternSubsumsjon(v1: EksternSubsumsjonBrukt): InternSubsumsjonBrukt {
-        val behandlingsId = subsumsjonStore.hentKoblingTilEkstern(EksternId(v1.eksternId.toString(), Kontekst.VEDTAK))
+    override fun eksternTilInternSubsumsjon(eksternSubsumsjonBrukt: EksternSubsumsjonBrukt): InternSubsumsjonBrukt {
+        val behandlingsId = subsumsjonStore.hentKoblingTilEkstern(
+            EksternId(
+                eksternSubsumsjonBrukt.eksternId.toString(),
+                Kontekst.VEDTAK
+            )
+        ) ?: throw SubsumsjonBruktNotFoundException("Could not find susbsumsjon based on $eksternSubsumsjonBrukt")
         return InternSubsumsjonBrukt(
-            id = v1.id,
+            id = eksternSubsumsjonBrukt.id,
             behandlingsId = behandlingsId.id,
-            arenaTs = v1.arenaTs,
+            arenaTs = eksternSubsumsjonBrukt.arenaTs,
             created = ZonedDateTime.ofInstant(
-                Instant.ofEpochMilli(v1.ts), ZoneOffset.UTC
+                Instant.ofEpochMilli(eksternSubsumsjonBrukt.ts), ZoneOffset.UTC
             )
         )
     }

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/PostgresSubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/PostgresSubsumsjonStore.kt
@@ -27,7 +27,7 @@ private val LOGGER = KotlinLogging.logger {}
 
 internal class PostgresSubsumsjonStore(private val dataSource: DataSource) : SubsumsjonStore, HealthCheck {
 
-    override fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId {
+    override fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId? {
         val id: String? = using(sessionOf(dataSource)) { session ->
             session.run(
                 queryOf(
@@ -38,10 +38,10 @@ internal class PostgresSubsumsjonStore(private val dataSource: DataSource) : Sub
                 }.asSingle
             )
         }
-        return id?.let { BehandlingsId(it, eksternId) } ?: opprettKoblingTilEkstern(eksternId)
+        return id?.let { BehandlingsId(it, eksternId) }
     }
 
-    private fun opprettKoblingTilEkstern(eksternId: EksternId): BehandlingsId {
+    override fun opprettKoblingTilEkstern(eksternId: EksternId): BehandlingsId {
         val behandlingsId = BehandlingsId.nyBehandlingsIdFraEksternId(eksternId)
         using(sessionOf(dataSource)) { session ->
             session.run(

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/db/SubsumsjonStore.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/db/SubsumsjonStore.kt
@@ -8,14 +8,15 @@ interface SubsumsjonStore {
 
     fun opprettBehov(behov: Behov): InternBehov {
         val eksternId = EksternId(behov.vedtakId.toString(), Kontekst.VEDTAK)
-        val behandlingsId = hentKoblingTilEkstern(eksternId)
+        val behandlingsId = hentKoblingTilEkstern(eksternId) ?: opprettKoblingTilEkstern(eksternId)
         val internBehov = InternBehov.fromBehov(behov, behandlingsId)
         insertBehov(internBehov)
         return internBehov
     }
 
     fun insertBehov(behov: InternBehov): Int
-    fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId
+    fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId?
+    fun opprettKoblingTilEkstern(eksternId: EksternId): BehandlingsId
     fun getBehov(behovId: BehovId): InternBehov
     fun behovStatus(behovId: BehovId): Status
     fun insertSubsumsjon(subsumsjon: Subsumsjon, created: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC"))): Int

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/streams/BruktSubsumsjonStrategy.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/streams/BruktSubsumsjonStrategy.kt
@@ -1,0 +1,24 @@
+package no.nav.dagpenger.regel.api.streams
+
+import mu.KotlinLogging
+import no.nav.dagpenger.regel.api.Vaktmester
+import no.nav.dagpenger.regel.api.db.BruktSubsumsjonStore
+import no.nav.dagpenger.regel.api.db.EksternSubsumsjonBrukt
+
+internal class BruktSubsumsjonStrategy(private val vaktmester: Vaktmester, private val bruktSubsumsjonStore: BruktSubsumsjonStore) {
+    private val logger = KotlinLogging.logger { }
+
+    fun handle(brukteSubsumsjoner: Sequence<EksternSubsumsjonBrukt>) {
+        brukteSubsumsjoner
+            .onEach { b -> logger.info("Received $b ") }
+            .filterNot { vedtak ->
+                "AVSLU" == vedtak.vedtakStatus && "AVBRUTT" == vedtak.utfall
+            }
+            .onEach { b -> logger.info("Saving $b to database") }
+            .forEach {
+                val internSubsumsjonBrukt = bruktSubsumsjonStore.eksternTilInternSubsumsjon(it)
+                bruktSubsumsjonStore.insertSubsumsjonBrukt(internSubsumsjonBrukt)
+                vaktmester.markerSomBrukt(internSubsumsjonBrukt)
+            }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/db/PostgresTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/db/PostgresTest.kt
@@ -222,7 +222,7 @@ class PostgresSubsumsjonStoreTest {
         withMigratedDb {
             with(PostgresSubsumsjonStore(DataSource.instance)) {
                 val eksternId = EksternId("1234", Kontekst.VEDTAK)
-                val behandlingsId: BehandlingsId = hentKoblingTilEkstern(eksternId)
+                val behandlingsId: BehandlingsId = opprettKoblingTilEkstern(eksternId)
                 ULID.parseULID(behandlingsId.id)
             }
         }
@@ -233,8 +233,8 @@ class PostgresSubsumsjonStoreTest {
         withMigratedDb {
             with(PostgresSubsumsjonStore(DataSource.instance)) {
                 val eksternId = EksternId("1234", Kontekst.VEDTAK)
-                val behandlingsId1: BehandlingsId = hentKoblingTilEkstern(eksternId)
-                val behandlingsId2: BehandlingsId = hentKoblingTilEkstern(eksternId)
+                val behandlingsId1: BehandlingsId? = hentKoblingTilEkstern(eksternId)
+                val behandlingsId2: BehandlingsId? = hentKoblingTilEkstern(eksternId)
                 behandlingsId1 shouldBe behandlingsId2
             }
         }

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/routing/BehovRouteTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/routing/BehovRouteTest.kt
@@ -100,8 +100,12 @@ class BehovRouteTest {
                 return 1
             }
 
-            override fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId {
+            override fun hentKoblingTilEkstern(eksternId: EksternId): BehandlingsId? {
                 return BehandlingsId.nyBehandlingsIdFraEksternId(eksternId)
+            }
+
+            override fun opprettKoblingTilEkstern(eksternId: EksternId): BehandlingsId {
+                TODO("not implemented")
             }
 
             override fun behovStatus(behovId: BehovId): Status {

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/streams/BruktSubsumsjonStrategyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/streams/BruktSubsumsjonStrategyTest.kt
@@ -1,0 +1,105 @@
+package no.nav.dagpenger.regel.api.streams
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.dagpenger.regel.api.Vaktmester
+import no.nav.dagpenger.regel.api.db.BruktSubsumsjonStore
+import no.nav.dagpenger.regel.api.db.EksternSubsumsjonBrukt
+import no.nav.dagpenger.regel.api.db.InternSubsumsjonBrukt
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+
+internal class BruktSubsumsjonStrategyTest {
+    @Test
+    fun `Should handle list of brukte subsumsjoner`() {
+        val now = ZonedDateTime.now()
+        val bruktSubsumsjon =
+            EksternSubsumsjonBrukt(
+                id = "test",
+                eksternId = 1234678L,
+                arenaTs = now,
+                ts = now.toInstant().toEpochMilli()
+            )
+
+        val storeMock = mockk<BruktSubsumsjonStore>(relaxed = false).apply {
+            every { this@apply.eksternTilInternSubsumsjon(any()) } returns InternSubsumsjonBrukt(
+                id = "test",
+                behandlingsId = "b",
+                arenaTs = now.minusMinutes(5)
+            )
+            every { this@apply.insertSubsumsjonBrukt(any()) } returns 1
+        }
+        val vaktmester = mockk<Vaktmester>(relaxed = true).apply {
+            every { this@apply.markerSomBrukt(any()) } returns Unit
+        }
+
+        val bb = BruktSubsumsjonStrategy(vaktmester = vaktmester, bruktSubsumsjonStore = storeMock)
+
+        bb.handle(sequenceOf(bruktSubsumsjon))
+
+        verify(exactly = 1) {
+            vaktmester.markerSomBrukt(any())
+        }
+
+        verify(exactly = 1) {
+            storeMock.insertSubsumsjonBrukt(any())
+        }
+    }
+
+    @Test
+    fun `Should filter out vedtak with status 'AVSLU' (avsluttet) og utfall 'Avbrutt'`() {
+        val now = ZonedDateTime.now()
+
+        val storeMock = mockk<BruktSubsumsjonStore>(relaxed = false).apply {
+            every { this@apply.eksternTilInternSubsumsjon(any()) } returns InternSubsumsjonBrukt(
+                id = "test",
+                behandlingsId = "b",
+                arenaTs = now.minusMinutes(5)
+            )
+            every { this@apply.insertSubsumsjonBrukt(any()) } returns 1
+        }
+        val vaktmester = mockk<Vaktmester>(relaxed = true).apply {
+            every { this@apply.markerSomBrukt(any()) } returns Unit
+        }
+
+        val bruktSubsumsjonStrategy = BruktSubsumsjonStrategy(vaktmester = vaktmester, bruktSubsumsjonStore = storeMock)
+
+        val brukteSubsumsjoner = sequenceOf(
+            EksternSubsumsjonBrukt(
+                id = "test",
+                eksternId = 1234678L,
+                arenaTs = now,
+                ts = now.toInstant().toEpochMilli(),
+                utfall = "AVBRUTT",
+                vedtakStatus = "AVSLU"
+            ),
+            EksternSubsumsjonBrukt(
+                id = "test",
+                eksternId = 1234678L,
+                arenaTs = now,
+                ts = now.toInstant().toEpochMilli(),
+                utfall = "NEI",
+                vedtakStatus = "AVSLU"
+            ),
+            EksternSubsumsjonBrukt(
+                id = "test",
+                eksternId = 1234678L,
+                arenaTs = now,
+                ts = now.toInstant().toEpochMilli(),
+                utfall = "JA",
+                vedtakStatus = "IVERK"
+            )
+        )
+
+        bruktSubsumsjonStrategy.handle(brukteSubsumsjoner)
+
+        verify(exactly = 2) {
+            vaktmester.markerSomBrukt(any())
+        }
+
+        verify(exactly = 2) {
+            storeMock.insertSubsumsjonBrukt(any())
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/streams/KafkaEksternSubsumsjonBruktConsumerTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/streams/KafkaEksternSubsumsjonBruktConsumerTest.kt
@@ -20,6 +20,7 @@ import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
 
 val LOGGER = KotlinLogging.logger { }
+
 class KafkaEksternSubsumsjonBruktConsumerTest {
     private object Kafka {
         val instance by lazy {
@@ -34,7 +35,11 @@ class KafkaEksternSubsumsjonBruktConsumerTest {
             val lagretTilDb = slot<InternSubsumsjonBrukt>()
             val markertSomBrukt = slot<InternSubsumsjonBrukt>()
             val storeMock = mockk<BruktSubsumsjonStore>(relaxed = false).apply {
-                every { this@apply.eksternTilInternSubsumsjon(any()) } returns InternSubsumsjonBrukt(id = "test", behandlingsId = "b", arenaTs = now.minusMinutes(5))
+                every { this@apply.eksternTilInternSubsumsjon(any()) } returns InternSubsumsjonBrukt(
+                    id = "test",
+                    behandlingsId = "b",
+                    arenaTs = now.minusMinutes(5)
+                )
                 every { this@apply.insertSubsumsjonBrukt(capture(lagretTilDb)) } returns 1
             }
             val vaktmester = mockk<Vaktmester>(relaxed = true).apply {
@@ -56,7 +61,12 @@ class KafkaEksternSubsumsjonBruktConsumerTest {
                     it[ProducerConfig.ACKS_CONFIG] = "all"
                 })
             val bruktSubsumsjon =
-                EksternSubsumsjonBrukt(id = "test", eksternId = 1234678L, arenaTs = now, ts = now.toInstant().toEpochMilli())
+                EksternSubsumsjonBrukt(
+                    id = "test",
+                    eksternId = 1234678L,
+                    arenaTs = now,
+                    ts = now.toInstant().toEpochMilli()
+                )
             val metaData = producer.send(ProducerRecord(config.subsumsjonBruktTopic, "test", bruktSubsumsjon.toJson()))
                 .get(5, TimeUnit.SECONDS)
             LOGGER.info("Producer produced $bruktSubsumsjon with meta $metaData")


### PR DESCRIPTION
Resultatlytter i dp-regel-api skal kaste feil hvis vedtaket ikke er registrert (ingen beregninger kjørt)

resolves navikt/dagpenger#285