### PR TITLE
Vi bumpa minne i https://github.com/navikt/dp-regel-api/commit/0e709b…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
-FROM navikt/java:11
+FROM navikt/java:12
 
 COPY build/libs/*.jar app.jar
+
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 \
+               -XX:+HeapDumpOnOutOfMemoryError \
+               -XX:HeapDumpPath=/oom-dump.hprof"
+RUN echo 'java -XX:MaxRAMPercentage=75 -XX:+PrintFlagsFinal -version | grep -Ei "maxheapsize|maxram"' > /init-scripts/0-dump-memory-config.sh


### PR DESCRIPTION
…695eac22f0db35d690547bf5c3d9bf800d men det ser ikke ut til at de blir utnytta i forhold til heap size, den GC'er ganske ofte enda. Lest meg litt opp på MaxRAMPercentage og i med at vi setter xmx spesifikt kan denne brukes (https://stackoverflow.com/questions/54292282/clarification-of-meaning-new-jvm-memory-parameters-initialrampercentage-and-minr)

Grafana https://grafana.adeo.no/d/000000283/nais-app-dashbord?orgId=1&dp-regel-api&from=now-7d&to=now&refresh=30s&var-interval=$__auto_interval_interval&var-datasource=prod-fss&var-app=dp-regel-api&var-namespace=All&var-docker_image=b8d446e&var-ingress_url=All